### PR TITLE
add docker packaging and ghcr ci workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+target
+.env
+artifacts
+monitoring
+*.log

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,49 @@
+name: Docker Build And Push
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        shell: bash
+        run: |
+          CURRENT_DATE_TIME="$(date +'%Y-%m-%d')"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          IMAGE_REPO="ghcr.io/utexo-protocol/btc-relayer"
+          echo "latest=${IMAGE_REPO}:latest" >> "$GITHUB_OUTPUT"
+          echo "backup=${IMAGE_REPO}:${CURRENT_DATE_TIME}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.latest }}
+            ${{ steps.tags.outputs.backup }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -25,8 +25,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Compute image tags
         id: tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.91-bookworm AS builder
+WORKDIR /app
+
+# Build dependencies first to improve layer caching.
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY tests ./tests
+RUN cargo build --release
+
+FROM debian:bookworm-slim AS runtime
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/btc-relayer /usr/local/bin/btc-relayer
+
+# Keep default state file parent directory available in container.
+RUN mkdir -p /app/artifacts
+
+ENV RUST_LOG=info
+ENV METRICS_BIND_ADDR=0.0.0.0:9090
+
+EXPOSE 9090
+
+ENTRYPOINT ["/usr/local/bin/btc-relayer"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Project config (tracked in repo).
+include config.mk
+
+export DOCKER_BUILDKIT=1
+
+.PHONY: build tag push docker run stop logs clean-image help
+
+build: ## Build Docker image once (latest tag).
+	docker build -f ./Dockerfile -t $(IMAGE_UTEXO_BTC_RELAY_LATEST) .
+
+tag: ## Tag latest image with backup tag.
+	docker tag $(IMAGE_UTEXO_BTC_RELAY_LATEST) $(IMAGE_UTEXO_BTC_RELAY_BACKUP)
+
+push: ## Push latest + backup tags.
+	docker push $(IMAGE_UTEXO_BTC_RELAY_LATEST)
+	docker push $(IMAGE_UTEXO_BTC_RELAY_BACKUP)
+
+docker: build tag push ## Build, tag and push image.
+
+run: ## Run relayer container with .env and persisted state.
+	mkdir -p $(ARTIFACTS_DIR)
+	docker run -d \
+		--name $(CONTAINER_NAME) \
+		--restart unless-stopped \
+		--env-file $(ENV_FILE) \
+		-p $(PORT):9090 \
+		-v $(ARTIFACTS_DIR):/app/artifacts \
+		$(IMAGE_UTEXO_BTC_RELAY_LATEST)
+
+stop: ## Stop and remove relayer container.
+	-docker stop $(CONTAINER_NAME)
+	-docker rm $(CONTAINER_NAME)
+
+logs: ## Tail relayer container logs.
+	docker logs -f $(CONTAINER_NAME)
+
+clean-image: ## Remove local image tags.
+	-docker rmi $(IMAGE_UTEXO_BTC_RELAY_LATEST)
+	-docker rmi $(IMAGE_UTEXO_BTC_RELAY_BACKUP)
+
+help: ## Show this help.
+	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Notes:
 - Triggers:
   - manual run (`workflow_dispatch`)
   - push to `main`
+- Required secrets:
+  - `GHCR_USERNAME`
+  - `GHCR_TOKEN` (PAT with `write:packages`)
 - Publishes two tags to GHCR:
   - `ghcr.io/utexo-protocol/btc-relayer:latest`
   - `ghcr.io/utexo-protocol/btc-relayer:<YYYY-MM-DD>-<shortsha>`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ Each module has a clear role (see `//!` headers in source). Not full onion archi
 2. Run daemon:
    - `cargo run`
 
+## Run In Docker
+
+1. Build image:
+   - `make build`
+2. Run with env file and persisted state:
+   - `make run`
+3. Follow logs:
+   - `make logs`
+
+Notes:
+
+- Container writes local checkpoint to `STATE_FILE_PATH` (default `/app/artifacts/relay-state.json`).
+- Metrics are exposed on `METRICS_BIND_ADDR` (default `0.0.0.0:9090` in container).
+- Use `--add-host=host.docker.internal:host-gateway` if your RPC endpoints run on host and you refer to `host.docker.internal`.
+- `make help` shows all available targets.
+- Shared defaults and image tag formulas live in `config.mk` (including `REGISTRY_HOST=ghcr.io/utexo-protocol`).
+- Image tags follow `IMAGE_UTEXO_BTC_RELAY_LATEST` / `IMAGE_UTEXO_BTC_RELAY_BACKUP` and support optional `ENVIRONMENT` suffix.
+
+## CI Docker Build/Push
+
+- Workflow: `.github/workflows/docker-build-push.yml`
+- Triggers:
+  - manual run (`workflow_dispatch`)
+  - push to `main`
+- Publishes two tags to GHCR:
+  - `ghcr.io/utexo-protocol/btc-relayer:latest`
+  - `ghcr.io/utexo-protocol/btc-relayer:<YYYY-MM-DD>-<shortsha>`
+
 ## Test
 
 - Run unit tests:

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,20 @@
+# Shared project defaults for Makefile.
+
+# Base variables.
+ENVIRONMENT    ?=
+IMAGE_TAG      ?= latest
+REGISTRY_HOST  ?= ghcr.io/utexo-protocol
+CONTAINER_NAME ?= btc-relayer
+ENV_FILE       ?= .env
+ARTIFACTS_DIR  ?= $(CURDIR)/artifacts
+PORT           ?= 9090
+
+CURRENT_DATE_TIME := $(shell date +'%Y-%m-%d')
+LATEST_COMMIT     := $(shell git rev-parse --short HEAD)
+
+# Image names.
+UTEXO_BTC_RELAY_IMAGE ?= btc-relayer
+
+# Variables for build — BTC Relay.
+IMAGE_UTEXO_BTC_RELAY_BACKUP = $(REGISTRY_HOST)/$(UTEXO_BTC_RELAY_IMAGE)$(ENVIRONMENT):$(CURRENT_DATE_TIME)-$(LATEST_COMMIT)
+IMAGE_UTEXO_BTC_RELAY_LATEST = $(REGISTRY_HOST)/$(UTEXO_BTC_RELAY_IMAGE)$(ENVIRONMENT):$(IMAGE_TAG)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  btc-relayer:
+    container_name: btc-relayer
+    image: ghcr.io/utexo-protocol/btc-relayer:latest
+    pull_policy: never
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./artifacts:/app/artifacts


### PR DESCRIPTION
Add Docker runtime assets, Makefile-based image lifecycle commands, docker-compose for local server runs, and a GitHub Actions workflow to build/push GHCR images with latest and date-sha tags.